### PR TITLE
Aligned easy_install and Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - source activate test-environment
   
 # end of conda install
-  - pip install Cython --install-option="--no-cython-compile" 
+  - pip install Cython==0.25.2 --install-option="--no-cython-compile" 
   - pip install -r requirements.txt
 
   - cd varnorm

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - source activate test-environment
   
 # end of conda install
-
+  - pip install Cython --install-option="--no-cython-compile" 
   - pip install -r requirements.txt
 
   - cd varnorm

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   
 # end of conda install
 
-  - pip install Cython --install-option="--no-cython-compile"
   - pip install -r requirements.txt
 
   - cd varnorm

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Phenopolis can be developed under Windows but requires some additional steps and
  * pip install scipy-0.18.1-cp27-cp27m-win32.whl –user
  * pip install biopython-1.68-cp27-cp27m-win32.whl –user
 * Execute [the shell script](https://github.com/pontikos/phenopolis/blob/master/easy_install.sh) 
-* pysam - disable the pysam imports. This package won't install on Windows.
-* primer3 (package name primer3-py) - disable the primer3 imports. This package won't install on Windows.
+* pysam - disable the pysam install and imports. This package won't install on Windows.
+* primer3 (package name primer3-py) - disable the primer3 install and imports. This package won't install on Windows.
 * The following line in easy_install.sh fails 
 ```sed -i '' 's/#NO_PHENOTIPS_INSTALLATION: //' phenopolis/views/__init__.py```
 instead, ensure that ```LOCAL=True``` is set in [views/\_\_init__.py](https://github.com/pontikos/phenopolis/blob/master/views/__init__.py) 

--- a/easy_install.sh
+++ b/easy_install.sh
@@ -7,6 +7,7 @@ python setup.py install --user
 cd ..
 
 # python packages required
+pip install Cython --install-option="--no-cython-compile" --user 
 pip install -r requirements.txt --user
 
 # For local install without Phenotips this will:

--- a/easy_install.sh
+++ b/easy_install.sh
@@ -1,44 +1,13 @@
-# python packages required
-
-pip install python-bencode --user
-pip install Cython --install-option="--no-cython-compile" --user
-pip install pycrypto --user
-pip install psycopg2 --user
-pip install phizz  --user
-pip install pymongo --user
-pip install myvariant --user
-pip install mygene --user
-pip install pysam --user
-pip install pygr --user
-pip install plotly --user
-pip install flask_httpauth --user
-pip install primer3-py --user
-pip install neo4j-driver --user
-pip install Flask --user
-pip install Flask-Session --user
-pip install Flask-Runner --user
-pip install Flask-Mail --user
-pip install Flask-ErrorMail --user
-pip install Flask-Compress --user
-pip install Flask-Error --user
-pip install Flask-Cache --user
-pip install flask_errormail --user
-pip install flask_debugtoolbar --user
-pip install biopython --user
-pip install pandas --user
-pip install scipy --user
-
-git clone https://github.com/weiyi-bitw/varnorm.git
+# Get phenopolis and its submodule.
+git clone https://github.com/pontikos/phenopolis.git
+cd phenopolis
+git submodule update --init --remote --recursive
 cd varnorm
 python setup.py install --user
 cd ..
 
-git clone https://github.com/counsyl/hgvs.git
-cd hgvs
-python setup.py install --user
-cd ..
-
-git clone https://github.com/pontikos/phenopolis.git
+# python packages required
+pip install -r requirements.txt --user
 
 # For local install without Phenotips this will:
 # 1) approve all logins as Phenotips is not running
@@ -127,4 +96,5 @@ ln -s $TEMPLATE_DIR_PATH $VIEWS_DIR_PATH/templates
 
 python runserver.py
 
+exec $SHELL
 

--- a/easy_install.sh
+++ b/easy_install.sh
@@ -8,7 +8,7 @@ cd ../..
 
 # python packages required
 pip install Cython==0.25.2 --install-option="--no-cython-compile" --user 
-pip install -r requirements.txt --user
+pip install -r phenopolis/requirements.txt --user
 
 # For local install without Phenotips this will:
 # 1) approve all logins as Phenotips is not running

--- a/easy_install.sh
+++ b/easy_install.sh
@@ -4,7 +4,7 @@ cd phenopolis
 git submodule update --init --remote --recursive
 cd varnorm
 python setup.py install --user
-cd ..
+cd ../..
 
 # python packages required
 pip install Cython==0.25.2 --install-option="--no-cython-compile" --user 

--- a/easy_install.sh
+++ b/easy_install.sh
@@ -7,7 +7,7 @@ python setup.py install --user
 cd ..
 
 # python packages required
-pip install Cython --install-option="--no-cython-compile" --user 
+pip install Cython==0.25.2 --install-option="--no-cython-compile" --user 
 pip install -r requirements.txt --user
 
 # For local install without Phenotips this will:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ neo4j-driver==1.0.2
 pandas==0.19.1
 phizz==0.2.3
 plotly==1.12.12
-primer3-py
+primer3-py==0.5.1
 psycopg2==2.6.2
 pycrypto==2.6.1
 pygr==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 biopython==1.68
+Cython==0.025.2 --install-option="--no-cython-compile"
 Flask==0.10.1
 Flask-Cache==0.13.1
 Flask-Compress==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ Flask-HTTPAuth==3.2.1
 Flask-Mail==0.9.1
 Flask-Runner==2.1.1
 Flask-Session==0.3.0
-hgvs
 mygene==3.0.0
 myvariant==0.3.1
 neo4j-driver==1.0.2
@@ -19,10 +18,9 @@ plotly==1.12.12
 primer3-py
 psycopg2==2.6.2
 pycrypto==2.6.1
-pycryptodome==3.4.3
 pygr==0.8.2
+pyhgvs==0.9.4
 pymongo==3.4.0
-pysam
-pytest==3.0.5
+pysam==0.9.1.4
 python-bencode==1.0.2
-#scipy==0.18.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 biopython==1.68
-Cython==0.025.2 --install-option="--no-cython-compile"
+Cython==0.25.2 --install-option="--no-cython-compile"
 Flask==0.10.1
 Flask-Cache==0.13.1
 Flask-Compress==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 biopython==1.68
-Cython==0.25.2 --install-option="--no-cython-compile"
 Flask==0.10.1
 Flask-Cache==0.13.1
 Flask-Compress==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask-HTTPAuth==3.2.1
 Flask-Mail==0.9.1
 Flask-Runner==2.1.1
 Flask-Session==0.3.0
+hgvs==0.5.0a6
 mygene==3.0.0
 myvariant==0.3.1
 neo4j-driver==1.0.2
@@ -19,7 +20,6 @@ primer3-py
 psycopg2==2.6.2
 pycrypto==2.6.1
 pygr==0.8.2
-pyhgvs==0.9.4
 pymongo==3.4.0
 pysam==0.9.1.4
 python-bencode==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,5 @@ pygr==0.8.2
 pymongo==3.4.0
 pysam==0.9.1.4
 python-bencode==1.0.2
+scipy==0.18.1 # This will fail for Travis or Windows, they use alternative means of installation.
 


### PR DESCRIPTION
Updated easy_install to get varnorm as a submodule and get hgvs from requirements.txt.

Aligned .travis.yml and easy_install by using requirements.txt.

Current imperfections – 
- cython version is duplicated in travis and easy_install.
- scipy version is duplicated in travis and requirements.txt

The version numbers are frozen in requirements.txt. We can easily update the version numbers using the print out of
pip freeze -r requirements.txt

Working towards a set of scripts along the lines of https://githubengineering.com/scripts-to-rule-them-all/
