### PR TITLE
Add coveralls, see coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,9 @@ script:
   - STATIC_DIR_PATH="$(readlink -f static)"
   - ln -s $STATIC_DIR_PATH $VIEWS_DIR_PATH/static
   - ln -s $TEMPLATE_DIR_PATH $VIEWS_DIR_PATH/templates  
-   
 # command to run coveralls (test coverage) and run tests 
-#  - coverage run --source=phenopolis phenopolis/tests/test_login.py
-#  - python tests/test_login.py
-  - python -m unittest discover
+  - coverage run --omit */site-packages/* -m unittest discover
+  
 after_success:
   coveralls
 


### PR DESCRIPTION
Added coveralls to calculate test coverage. The phenopolis repo first needs to be registered with coveralls. Go to coveralls.io, log in with GitHub, add repo. Then, Travis will use coveralls for every test run and the coveralls page will report test coverage and show line by line where the coverage is. A badge with the % coverage can be added to README - see the 'embed' button on the coveralls page.