### PR TITLE
Display version on home page

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -72,6 +72,12 @@
                             NIHR (UCL-Moorfields Eyes Hospital Biomedical Research Center)
                             and in part by the UK Medical Research Council and the British Heart Foundation.
                             </p>
+							
+							<p>
+							{% if version_number %}
+							Version {{ version_number }}
+							{% endif %}
+                            </p>
 
                             <h3 align="center"> Samples </h3>
                             <p>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -73,10 +73,10 @@
                             and in part by the UK Medical Research Council and the British Heart Foundation.
                             </p>
 							
-							<p>
-							{% if version_number %}
-							Version {{ version_number }}
-							{% endif %}
+                            <p>
+                            {% if version_number %}
+                            Version {{ version_number }}
+                            {% endif %}
                             </p>
 
                             <h3 align="center"> Samples </h3>

--- a/views/home.py
+++ b/views/home.py
@@ -85,6 +85,8 @@ def homepage():
         version_number = subprocess.check_output(['git', 'describe', '--exact-match'])
     except:
         version_number = None
+    print('Version number is:-')
+    print(version_number)
 
     t = render_template('homepage.html',
         title='home',

--- a/views/home.py
+++ b/views/home.py
@@ -8,6 +8,7 @@ import pysam
 import csv
 #hpo lookup
 import orm
+import subprocess
 
 
 
@@ -79,6 +80,7 @@ def homepage():
     #image=urllib.quote(base64.b64encode(imgdata.buf))
     #image=imgdata.buf
     #image = '<svg' + image.split('<svg')[1]
+    version_number = subprocess.check_output(['git', 'describe'])
     t = render_template('homepage.html',
         title='home',
         total_patients=total_patients,
@@ -93,7 +95,8 @@ def homepage():
         pass_exac_variants=pass_exac_variants,
         pass_nonexac_variants=pass_nonexac_variants,
         #image=image.decode('utf8'))
-        image="")
+        image="",
+        version_number=version_number)
     #cache.set(cache_key, t)
     return t
 

--- a/views/home.py
+++ b/views/home.py
@@ -80,7 +80,12 @@ def homepage():
     #image=urllib.quote(base64.b64encode(imgdata.buf))
     #image=imgdata.buf
     #image = '<svg' + image.split('<svg')[1]
-    version_number = subprocess.check_output(['git', 'describe'])
+
+    try:
+        version_number = subprocess.check_output(['git', 'describe', '--exact-match'])
+    except:
+        version_number = None
+
     t = render_template('homepage.html',
         title='home',
         total_patients=total_patients,


### PR DESCRIPTION
Added display of Phenopolis version number to the home page, at the end of the “About” section. The version number is the github tag number, e.g. v1.0.2, which you can set. If the code has not been tagged, nothing will display. If it has been tagged it will display “Version v1.0.2” between “British Heart Foundation” and “Samples”.

To add a tag -
git tag -a v1.0.2 -m "Added some new feature..."
git push origin v1.0.2

You can set things up to deploy code whenever you add a tag to github. I.e. you can use the action of adding a tag to trigger deployment. To do this, add your deployment script to the deploy section at the end of travis.yml and set it to deploy only when tags: true and only on master branch. See https://docs.travis-ci.com/user/deployment/script/
