### PR TITLE
Added switch to handle imports

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,2 +1,8 @@
+import sys 
+
+if len(sys.argv)>1 and sys.argv[1]=='SERVER':
+    LOCAL=False
+else:
+    LOCAL=True
 
 IMPORT_PYSAM_PRIMER3 = True # Set this to False to develop on Windows, where pysam and primer3 fail to install.

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,2 @@
+
+IMPORT_PYSAM_PRIMER3 = True # Set this to False to develop on Windows, where pysam and primer3 fail to install.

--- a/lookups.py
+++ b/lookups.py
@@ -1,7 +1,9 @@
 import re
 from utils import *
 import itertools
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 #hpo lookup
 import random

--- a/lookups/lookups.py
+++ b/lookups/lookups.py
@@ -1,7 +1,9 @@
 import re
 #from utils import *
 import itertools
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 #hpo lookup
 import phizz

--- a/runserver.py
+++ b/runserver.py
@@ -1,16 +1,12 @@
 import sys
 from views import *
+from config import config
 
 # Load default config and override config from an environment variable
-global LOCAL
-
-if len(sys.argv)>1 and sys.argv[1]=='SERVER':
-    LOCAL=False
-    app.config.from_pyfile('../phenopolis.cfg')
-else:
-    LOCAL=True
+if config.LOCAL:
     app.config.from_pyfile('../local.cfg')
-
+else:
+    app.config.from_pyfile('../phenopolis.cfg')
 
 
 if __name__ == "__main__":

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -1,0 +1,19 @@
+
+import unittest
+from config import config
+
+
+class ConfigTestCase(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_import_flag(self):
+        assert config.IMPORT_PYSAM_PRIMER3 == True
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vcf/__init__.py
+++ b/vcf/__init__.py
@@ -1,5 +1,7 @@
 
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 
 # VCF query
 def vcf_query(chrom=None, pos=None, ref=None, alt=None, variant_str=None, individual=None, verbose=False, limit=100, release='mainset_July2016'):

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -42,7 +42,9 @@ import itertools
 import json
 import os
 import pymongo
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import gzip
 import logging
 import lookups

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,3 @@
-global LOCAL
 
 #flask import
 from flask import Flask
@@ -83,21 +82,20 @@ import base64
 
 import orm
 from lookups import *
+from config import config
 
 logging.getLogger().addHandler(logging.StreamHandler())
 logging.getLogger().setLevel(logging.INFO)
 
-if len(sys.argv)>1 and sys.argv[1]=='SERVER':
-    LOCAL=False
-else:
-    LOCAL=True
-
-if LOCAL:
+# Load default config and override config from an environment variable
+if config.LOCAL:
     print 'LOCAL'
     app = Flask(__name__,static_url_path='/static')
+    app.config.from_pyfile('../local.cfg')
 else:
     print 'SERVER'
     app = Flask(__name__)
+    app.config.from_pyfile('../phenopolis.cfg')
 
 ADMINISTRATORS = ( 'n.pontikos@ucl.ac.uk',)
 mail_on_500(app, ADMINISTRATORS)
@@ -111,13 +109,6 @@ cache = Cache(app,config={'CACHE_TYPE': 'simple'})
 
 REGION_LIMIT = 1E5
 EXON_PADDING = 50
-# Load default config and override config from an environment variable
-if LOCAL:
-    print 'LOCAL'
-    app.config.from_pyfile('../local.cfg')
-else:
-    print 'SERVER'
-    app.config.from_pyfile('../phenopolis.cfg')
 
 # Check Configuration section for more details
 SESSION_TYPE = 'mongodb'
@@ -133,7 +124,7 @@ def check_auth(username, password):
     Will try to connect to phenotips instance.
     """
     print username
-    if LOCAL:
+    if config.LOCAL:
         print 'LOCAL'
         if username=='demo' and password=='demo123':
             session['password2'] = password
@@ -182,7 +173,7 @@ def requires_auth(f):
              return f(*args, **kwargs)
           else:
              print 'login'
-             if LOCAL:
+             if config.LOCAL:
                  return redirect('login')
              else:
                  return redirect('https://uclex.cs.ucl.ac.uk/login')
@@ -195,7 +186,7 @@ def requires_auth(f):
           if check_auth(username,password):
              return f(*args, **kwargs)
           else:
-             if LOCAL:
+             if config.LOCAL:
                  return render_template('login.html', error='Invalid Credentials. Please try again.')
              else:
                  return redirect('https://uclex.cs.ucl.ac.uk/login')
@@ -220,7 +211,7 @@ def login():
           error = 'Invalid Credentials. Please try again.'
        else:
            print 'LOGIN SUCCESS'
-           if LOCAL:
+           if config.LOCAL:
                return redirect('/')
            else:
                return redirect('https://uclex.cs.ucl.ac.uk/')
@@ -238,7 +229,7 @@ def login2():
        if not check_auth(username,password):
           error = 'Invalid Credentials. Please try again.'
        else:
-           if LOCAL:
+           if config.LOCAL:
                return redirect('/')
            else:
                return redirect('https://uclex.cs.ucl.ac.uk')
@@ -252,7 +243,7 @@ def logout():
     session.pop('user',None)
     session.pop('password',None)
     session.pop('password2',None)
-    if LOCAL:
+    if config.LOCAL:
         return redirect('/login')
     else:
         return redirect('https://uclex.cs.ucl.ac.uk/login')

--- a/views/gene.py
+++ b/views/gene.py
@@ -3,7 +3,9 @@ from lookups import *
 from orm import *
 import rest as annotation
 import requests
-import primer3
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import primer3
 import myvariant
 from vcf import vcf_query
 import hashlib

--- a/views/home.py
+++ b/views/home.py
@@ -4,7 +4,9 @@ import requests
 import re
 from utils import *
 import itertools
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 #hpo lookup
 import orm

--- a/views/home.py
+++ b/views/home.py
@@ -31,7 +31,7 @@ def homepage():
     female_patients=patients_db.patients.find( {'sex':'F'}).count()
     print('female_patients',female_patients,)
     unknown_patients=patients_db.patients.find( {'sex':'U'}).count()
-    if LOCAL:
+    if config.LOCAL:
         hpo_json={}
     else:
         hpo_file='uclex_stats/overall_hpo_2016_Aug_2.json'

--- a/views/hpo.py
+++ b/views/hpo.py
@@ -2,12 +2,14 @@ from views import *
 from lookups import *
 import rest as annotation
 import requests
-import primer3
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
+    import primer3
 import myvariant
 import re
 from utils import *
 import itertools
-import pysam
 import csv
 #hpo lookup
 import phizz

--- a/views/igv.py
+++ b/views/igv.py
@@ -4,7 +4,9 @@ import requests
 import re
 from utils import *
 import itertools
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 #hpo lookup
 import random

--- a/views/individual.py
+++ b/views/individual.py
@@ -4,7 +4,9 @@ import requests
 import re
 from utils import *
 import itertools
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 #hpo lookup
 import orm

--- a/views/individuals.py
+++ b/views/individuals.py
@@ -4,7 +4,9 @@ import requests
 import re
 from utils import *
 import itertools
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 #hpo lookup
 import orm

--- a/views/load_individual.py
+++ b/views/load_individual.py
@@ -18,7 +18,9 @@ import sys
 import re
 import itertools
 from urllib2 import HTTPError, URLError
-import pysam
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
 import csv
 from collections import defaultdict, Counter
 #import rest as annotation

--- a/views/pheno4j.py
+++ b/views/pheno4j.py
@@ -4,7 +4,9 @@ from lookups import *
 from orm import *
 import rest as annotation
 import requests
-import primer3
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import primer3
 import myvariant
 from vcf import vcf_query
 import hashlib

--- a/views/variant.py
+++ b/views/variant.py
@@ -3,12 +3,14 @@ from views import *
 from lookups import *
 import rest as annotation
 import requests
-import primer3
+from config import config
+if config.IMPORT_PYSAM_PRIMER3:
+    import pysam
+    import primer3
 import myvariant
 import re
 from utils import *
 import itertools
-import pysam
 import csv
 #hpo lookup
 import phizz


### PR DESCRIPTION
Added config module. 

Added flag to enable easy switch off of pysam and primer3 imports, which don't install on Windows. Added test to check that this flag is turned to True, to do the imports.

Moved global LOCAL to config module since it was defined in a couple of places already.