### PR TITLE
update login Logic

### DIFF
--- a/templates/material_layout.html
+++ b/templates/material_layout.html
@@ -98,14 +98,15 @@
                         <input id="password" type="password" placeholder="demo123" name="password" value="{{request.form.password }}" class="validate">
                         <label for="password">Password</label>
                     </div>
+                    <p class="col s12" id="login_form_error_msg" style="display:none; color: #F44336; margin-top: 0; margin-left: -1em;">Authentication failed. Please enter your username and passsword again.<br>Contact us if you continue to have issues logging in.</p>
                 </div>
             </form>
             <p>Alternatively, select the 'Demo Login' button below to login as a demo user.</p>
         </div>
         <div class="modal-footer" style="border-top: 1px solid rgba(0, 0, 0, 0.1)">
             <a href="#!" class="left modal-action modal-close waves-effect waves-red btn-flat">Close</a>
-            <a id="login_btn" href="#!" type="submit" class="modal-action modal-close waves-effect waves-green btn-flat">Login</a>
-            <a id="demo_login_btn" href="#!" type="submit" class="modal-action modal-close waves-effect waves-green btn-flat">Demo Login</a>
+            <a id="login_btn" href="#!" type="submit" class="waves-effect waves-green btn-flat">Login</a>
+            <a id="demo_login_btn" href="#!" type="submit" class="waves-effect waves-green btn-flat">Demo Login</a>
         </div>
     </div>
 
@@ -119,22 +120,41 @@
 
         // Submit form upon clicking the login button in the modal
         $('#login_btn').on('click', function() {
-            $('#login_form').submit();
+            PPlogin();
         });
 
-        // Automatically login when selecting the login button
+        // Automatically login when selecting the demo login button
         $('#demo_login_btn, #parallax_demo_login_btn').on('click', function() {
             $('#username').val('demo');
             $('#password').val('demo123');
-            $('#login_form').submit();
+            PPlogin();
         });
 
         // submit form upon pressing enter in the login form
         $('#login_form input').keydown(function(e) {
             if (e.keyCode == 13) {
-                $('#login_form').submit();
+                PPlogin();
             }
         });
+
+        var PPlogin = function() {
+            // TODO: Replace with JQuery.validate
+            $.ajax({
+                type: 'POST',
+                url: '/login',
+                data: $('#login_form').serialize(),
+                dataType: 'json',
+                timeout: 120000,
+                success: function(data) {
+                    window.location.href = '/search';
+                },
+                error: function(data, msg) {
+                    $("#username, #password").addClass("invalid");
+                    $("#username, #password").prop("aria-invalid", "true");
+                    $('#login_form_error_msg').show();
+                }
+            });
+        };
     });
     </script>
 </body>

--- a/tests/server/test_login.py
+++ b/tests/server/test_login.py
@@ -27,16 +27,16 @@ class LoginTestCase(unittest.TestCase):
 
     def test_login_logout(self):
         rv = self.login('demox', 'demo123')
-        assert rv.status_code == 403
+        assert rv.status_code == 401
         assert 'Invalid Credentials. Please try again.' in rv.data
         
         rv = self.login('demo', 'demo123x')
-        assert rv.status_code == 403
+        assert rv.status_code == 401
         assert 'Invalid Credentials. Please try again.' in rv.data
         
         rv = self.login('demo', 'demo123')
         assert rv.status_code == 200
-        assert 'Search Page' and 'HPO Browser' in rv.data
+        assert 'Authenticated' in rv.data
         
         rv = self.logout()
         assert rv.status_code == 200


### PR DESCRIPTION
- Most importantly, display an error message when authentication fails
- Make `/login` a POST only
- `/login` returns a json rather than redirecting...
- `requires_auth()` cleaned up and it now checks authentication on `GET`s as well as POSTs...
    - atm, this returns a redirect - ideally, this should return a JSON, that is handled Client side (it also makes it easier for others to use as an API) - I'll update this later...
- Corrected failed authentication status code from 403 to 401...
