### PR TITLE
Authentication algo

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -7,4 +7,4 @@ else:
 
 IMPORT_PYSAM_PRIMER3 = True # Set this to False to develop on Windows, where pysam and primer3 fail to install.
 
-USE_ARGON2_AUTH = False # To test, populate USER_DB by entering  >>mongoimport --db users --collection users --file tests/data/users_argon2.json --drop
+USE_ARGON2_AUTH = False # To test, set to True and populate USER_DB by entering  >>mongoimport --db users --collection users --file tests/data/users_argon2.json --drop

--- a/config/config.py
+++ b/config/config.py
@@ -6,3 +6,5 @@ else:
     LOCAL=True
 
 IMPORT_PYSAM_PRIMER3 = True # Set this to False to develop on Windows, where pysam and primer3 fail to install.
+
+USE_ARGON2_AUTH = False # To test, populate USER_DB by entering  >>mongoimport --db users --collection users --file tests/data/users_argon2.json --drop

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ pysam==0.9.1.4 			# Can't be installed on Windows.
 python-bencode==1.0.2
 scipy==0.18.1 			# This will fail for Travis or Windows, they use alternative means of installation.
 django-htmlmin==0.10.0
-lxml
+lxml==3.7.3
 bs4==0.0.1
+passlib==1.7.1
+argon2_cffi==16.3.0
 

--- a/tests/data/users_argon2.json
+++ b/tests/data/users_argon2.json
@@ -1,0 +1,1 @@
+{"user" : "demo", "password" : "$argon2i$v=19$m=512,t=2,p=2$n1PK2XvvXcs5h/Aewzjn3A$PxZq8Hwae2EZ4RZX204qsQ", "external_ids" : [ "WebsterURMD_Sample_GV4344", "WebsterURMD_Sample_IC16489", "WebsterURMD_Sample_SJ17898", "WebsterURMD_Sample_SK13768" ] }

--- a/tests/load_data.py
+++ b/tests/load_data.py
@@ -3,6 +3,7 @@ import pymongo
 from pymongo import MongoClient
 from flask import Flask, current_app
 import views
+from config import config
 
 # Load the test data set.
 def load_data():
@@ -26,7 +27,10 @@ def load_data():
         import_data('test_hpo', 'genes_pheno', "./tests/data/hpo-genes_pheno-TTLL5.json", indexes)
         indexes = ['external_id', 'report_id', 'features.id', 'sex', 'genes.gene', 'solved', 'clinicalStatus.clinicalStatus', 'specificity.score']
         import_data('test_patients', 'patients', "./tests/data/patients-patients-hidden.json", indexes)
-        import_data('test_users', 'users', "./tests/data/users.json")
+        if not config.USE_ARGON2_AUTH:
+            import_data('test_users', 'users', "./tests/data/users.json")
+        else:
+            import_data('test_users', 'users', "./tests/data/users_argon2.json")
 
 
 # Create a collection in the db, drop any existing data, add data from file.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,8 @@ class ConfigTestCase(unittest.TestCase):
         pass
 
     def test_import_flag(self):
-        assert config.IMPORT_PYSAM_PRIMER3 == True    
+        assert config.IMPORT_PYSAM_PRIMER3 == True # This needs to be True before committing to the repo.    
+        assert config.USE_ARGON2_AUTH == False # This needs to be False before committing to the repo. 
 
 if __name__ == '__main__':
     unittest.main()

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -78,6 +78,7 @@ from Crypto.Cipher import DES
 import base64
 from binascii import b2a_base64, a2b_base64
 from werkzeug.security import generate_password_hash, check_password_hash
+from passlib.hash import argon2
 
 import orm
 from lookups import *
@@ -135,7 +136,11 @@ def check_auth(username, password):
     if not r: return False
     session['user']=username
     auth='%s:%s' % (username, password,)
-    return check_password_hash(r['password'],password)
+    if not config.USE_ARGON2_AUTH:
+        return check_password_hash(r['password'],password)
+    else:
+        return argon2.verify(password, r['password'])
+
 
 def authenticate():
     """Sends a 401 response that enables basic auth"""


### PR DESCRIPTION
Add authentication using argon2 algorithm (inactive by default). Issue #113 

To test - 
```pip install -r phenopolis/requirements.txt --user```
```mongoimport --db users --collection users --file tests/data/users_argon2.json --drop```
set config/config.py ```USE_ARGON2_AUTH = True```

Unit tested in test_login.py (this loads users_argon2.json or users.json according to USE_ARGON2_AUTH).

@pontikos - this can be merged in if you are happy with it. We then need a plan to -
port the live user db over to this algo 
and 
switch the code to ```USE_ARGON2_AUTH = True``` at the same time (inc. update test_config.py). 
After that, this config flag and old algo code can be removed.