### PR TITLE
Validate new password

### DIFF
--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -211,10 +211,15 @@ if (!PP) {
       var password = $("#new_password_1").val();
       var confirmPassword = $("#new_password_2").val();
 
-      if (password != confirmPassword)
+      if (password != confirmPassword) {
           $('#password_mismatch_msg').show();
-      else
+          $('#change_password_btn').attr('disabled', 'disabled');
+
+      }
+      else {
           $('#password_mismatch_msg').hide();
+          $('#change_password_btn').removeAttr('disabled');
+      }
   }
 }());
 // End of PP module

--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -65,6 +65,11 @@ if (!PP) {
     $('#submit_change_password_btn').on('click', function () {
         PP.submitChangePassword();
     });
+
+    $(document).ready(function () {
+        $("#new_password_1, #new_password_2").keyup(PP.checkPasswordMatch);
+    });
+
   };
 
   // TODO: Replace with JQuery.validate
@@ -200,5 +205,15 @@ if (!PP) {
           }
       });
   };
+
+  PP.checkPasswordMatch = function () {
+      var password = $("#new_password_1").val();
+      var confirmPassword = $("#new_password_2").val();
+
+      if (password != confirmPassword)
+          $("#divCheckPasswordMatch").html("Passwords do not match");
+      else
+          $("#divCheckPasswordMatch").html("Passwords match");
+  }
 }());
 // End of PP module

--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -184,6 +184,7 @@ if (!PP) {
       $('#auth_modal').modal('open');
       $('#change_password_form_error_msg').hide();
       $('#change_password_successful').hide();
+      $('#password_mismatch_msg').hide();
 
       $.ajax({
           type: 'POST',
@@ -211,9 +212,9 @@ if (!PP) {
       var confirmPassword = $("#new_password_2").val();
 
       if (password != confirmPassword)
-          $("#divCheckPasswordMatch").html("Passwords do not match");
+          $('#password_mismatch_msg').show();
       else
-          $("#divCheckPasswordMatch").html("Passwords match");
+          $('#password_mismatch_msg').hide();
   }
 }());
 // End of PP module

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -72,12 +72,12 @@
                 </div>
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
-                    <input id="new_password_1" type="password" name="new_password_1" class="validate" onChange="checkPasswordMatch();">
+                    <input id="new_password_1" type="password" name="new_password_1" class="validate">
                     <label for="new_password_1">New password</label>
                 </div>
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
-                    <input id="new_password_2" type="password" name="new_password_2" class="validate" onChange="checkPasswordMatch();">
+                    <input id="new_password_2" type="password" name="new_password_2" class="validate">
                     <label for="new_password_2">Retype new password</label>
                 </div>
                 <div class="registrationFormAlert" id="divCheckPasswordMatch">
@@ -97,7 +97,7 @@
         <a id="change_password_btn" href="#!" class="left waves-effect waves-green btn-flat">Change Password</a>
         <a id="register_btn" href="#!" class="left waves-effect waves-green btn-flat">Register</a>
         <a id="enter_login_btn" href="#!" class="left waves-effect waves-green btn-flat" style="display:none;">Login</a>
-        <!-- Right side of fotter -->
+        <!-- Right side of footer -->
         <a id="submit_register_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Submit</a>
         <a id="submit_change_password_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
         <a id="login_btn" href="#!" class="waves-effect waves-green btn-flat">Login</a>

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -82,6 +82,9 @@
                 </div>
                 <div class="registrationFormAlert" id="divCheckPasswordMatch">
                 </div>
+                <p class="col s12" id="password_mismatch_msg" style="display:none; color: #F44336; margin-top: 0; margin-left: -1em;">
+                    Passwords do not match.
+                </p>
                 <p class="col s12" id="change_password_form_error_msg" style="display:none; color: #F44336; margin-top: 0; margin-left: -1em;">
                     Password change failed. Please try again.
                     <br>Contact us if you continue to have issues.

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -72,13 +72,15 @@
                 </div>
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
-                    <input id="new_password_1" type="password" name="new_password_1" class="validate">
+                    <input id="new_password_1" type="password" name="new_password_1" class="validate" onChange="checkPasswordMatch();">
                     <label for="new_password_1">New password</label>
                 </div>
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
-                    <input id="new_password_2" type="password" name="new_password_2" class="validate">
+                    <input id="new_password_2" type="password" name="new_password_2" class="validate" onChange="checkPasswordMatch();">
                     <label for="new_password_2">Retype new password</label>
+                </div>
+                <div class="registrationFormAlert" id="divCheckPasswordMatch">
                 </div>
                 <p class="col s12" id="change_password_form_error_msg" style="display:none; color: #F44336; margin-top: 0; margin-left: -1em;">
                     Password change failed. Please try again.


### PR DESCRIPTION
Change Password form - Client side check that new password and retyped password match.

Attempting to disable 'change password' button if passwords don't match - not working.

@IsmailM how can I disable 'change password' button if the passwords don't match?

This is a simple client side check that we can have up and running whilst working on the JQuery validation. 