### PR TITLE
Turn off failing scrutinizer-ci.com test run. 

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,8 @@
+# This turns off the test run.
+build: false
+
+# If you do want the tests to run, delete the line "build: false" and uncomment the lines below.
+#build:
+    #dependencies:
+    #    before:
+    #        - 'pip install Cython==0.25.2 --install-option="--no-cython-compile"'


### PR DESCRIPTION
Turn off failing scrutinizer-ci.com test run. It was failing because cython wasn't installed.

Added comment lines that can be used if you want to install cython and turn the test run on. The tests run in Travis so they don't need to be run in Scrutinizer too.