### PR TITLE
Jquery validation

### DIFF
--- a/static/assets/js/phenopolis.js
+++ b/static/assets/js/phenopolis.js
@@ -150,7 +150,7 @@ if (!PP) {
         new_password_2: {
           equalTo: 'Both new passwords must match.'
         }
-      }
+      },
       submitHandler: function(form) {
         $('#auth_modal').modal({ dismissible: false, endingTop: '20%' });
         $('#auth_modal').modal('open');
@@ -168,7 +168,7 @@ if (!PP) {
                 $('#change_password_successful').show();
                 $("#change_password_successful").text(data.success);
             },
-            error: function (xhr, msg) {
+            error: function (data, msg) {
                 $('#auth_modal').modal('close');
                 $("#username, #password, #new_password_1, #new_password_2").addClass("invalid");
                 $("#username, #password, #new_password_1, #new_password_2").prop("aria-invalid", "true");

--- a/templates/components/change_password_modal.html
+++ b/templates/components/change_password_modal.html
@@ -7,7 +7,7 @@
             <div class="row">
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
-                    <input id="change_pwd_name" type="text" value={{session['user'].title() }} name="change_pwd_name">
+                    <input id="change_pwd_name" type="text" value={{session['user']}} name="change_pwd_name">
                     <label for="change_pwd_name">Hello</label>
                 </div>
                 <div class="input-field col s12">

--- a/templates/components/change_password_modal.html
+++ b/templates/components/change_password_modal.html
@@ -5,11 +5,7 @@
         <h4>Change Password</h4>
         <form id="change_password_form" class="col s12">
             <div class="row">
-                <div class="input-field col s12">
-                    <i class="material-icons prefix">lock</i>
-                    <input id="change_pwd_name" type="text" value={{session['user']}} name="change_pwd_name">
-                    <label for="change_pwd_name">Hello</label>
-                </div>
+                <input id="change_pwd_name" type="hidden" value={{session['user']}} name="change_pwd_name">
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
                     <input id="current_password" type="password" name="current_password">

--- a/templates/components/change_password_modal.html
+++ b/templates/components/change_password_modal.html
@@ -26,7 +26,7 @@
                     <br>Contact us if you continue to have issues.
                 </p>
             </div>
-</form>
+        </form>
         <p id="change_password_successful" style="color:#4CAF50; display: none;">Your password has been changed.</p>
     </div>
     <div class="modal-footer" style="border-top: 1px solid rgba(0, 0, 0, 0.1)">

--- a/templates/components/change_password_modal.html
+++ b/templates/components/change_password_modal.html
@@ -4,8 +4,12 @@
         <i class="material-icons right modal-close">close</i>
         <h4>Change Password</h4>
         <form id="change_password_form" class="col s12">
-            <input type="hidden" value="{{username}}" name="name">
             <div class="row">
+                <div class="input-field col s12">
+                    <i class="material-icons prefix">lock</i>
+                    <input id="change_pwd_name" type="text" value={{session['user'].title() }} name="change_pwd_name">
+                    <label for="change_pwd_name">Hello</label>
+                </div>
                 <div class="input-field col s12">
                     <i class="material-icons prefix">lock</i>
                     <input id="current_password" type="password" name="current_password">
@@ -26,7 +30,7 @@
                     <br>Contact us if you continue to have issues.
                 </p>
             </div>
-        </form>
+</form>
         <p id="change_password_successful" style="color:#4CAF50; display: none;">Your password has been changed.</p>
     </div>
     <div class="modal-footer" style="border-top: 1px solid rgba(0, 0, 0, 0.1)">

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -16,7 +16,7 @@
                     <input id="password" type="password" placeholder="demo123" name="password">
                     <label for="password">Password</label>
                 </div>
-                <p class="col s12" id="login_form_error_msg" style="display:none; color: #F44336; margin-top: 0; margin-left: -1em;">Authentication failed. Please enter your username and passsword again.<br>Contact us if you continue to have issues logging in.</p>
+                <p class="col s12" id="login_form_error_msg" style="display:none; color: #F44336; margin-top: 0; margin-left: -1em;">Authentication failed. Please enter your username and password again.<br>Contact us if you continue to have issues logging in.</p>
             </div>
         </form>
         <p>Alternatively, select the 'Demo Login' button below to login as a demo user.</p>

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,7 +1,7 @@
 
 # Uncomment to run this module directly.
-import sys, os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+#import sys, os
+#sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 # End of uncomment.
 
 import load_data

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,7 +1,7 @@
 
 # Uncomment to run this module directly.
-#import sys, os
-#sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 # End of uncomment.
 
 import load_data
@@ -33,12 +33,11 @@ class LoginTestCase(unittest.TestCase):
     def logout(self):
         return self.app.get('/logout', follow_redirects=True)
 
-    def change_password(self, username, password, new_pass_1, new_pass_2):
+    def change_password(self, username, password, new_pass_1):
         return self.app.post('/change_password', data=dict(
-            name=username,
+            change_pwd_name=username,
             current_password=password,
             new_password_1=new_pass_1,
-            new_password_2=new_pass_2
         ), follow_redirects=True)
 
     def test_login_logout(self):
@@ -60,7 +59,7 @@ class LoginTestCase(unittest.TestCase):
         assert rv.status_code == 200
         assert 'Authenticated' in rv.data
 
-        rv = self.change_password('test', 'test123', 'test456', 'test456')
+        rv = self.change_password('test', 'test123', 'test456')
         assert rv.status_code == 200
         print(rv.data)
         assert 'Password for username \'test\' changed' in rv.data
@@ -72,19 +71,16 @@ class LoginTestCase(unittest.TestCase):
         rv = self.login('test', 'test123')
         assert rv.status_code == 401
 
-        rv = self.change_password('test', 'test456', 'test123', 'test123')
+        rv = self.change_password('test', 'test456', 'test123')
         assert rv.status_code == 200
 
-        rv = self.change_password('demo', 'demo123', 'demo456', 'demo456')
+        rv = self.change_password('demo', 'demo123', 'demo456')
         assert rv.status_code == 401
 
-        rv = self.change_password('test', 'test123', 'x', 'test456')
+        rv = self.change_password('test', 'x', 'test456')
         assert rv.status_code == 401
 
-        rv = self.change_password('test', 'x', 'test456', 'test456')
-        assert rv.status_code == 401
-
-        rv = self.change_password('x', 'test123', 'test456', 'test456')
+        rv = self.change_password('x', 'test123', 'test456')
         assert rv.status_code == 401
 
 if __name__ == '__main__':

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -193,7 +193,6 @@ def logout():
 # 
 @app.route('/change_password', methods=['POST'])
 def change_password():
-    print 'CHANGING PASSWORD function'
     username = request.form['change_pwd_name']
     password = request.form['current_password']
     new_password_1 = request.form['new_password_1']

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -197,11 +197,8 @@ def change_password():
     username = request.form['change_pwd_name']
     password = request.form['current_password']
     new_password_1 = request.form['new_password_1']
-    new_password_2 = request.form['new_password_2']
     if username == 'demo': 
         return jsonify(error='You do not have permission to change the password for username \'demo\'.'), 401
-    elif new_password_1 != new_password_2: 
-        return jsonify(error='New password and re-typed password do not match. Please try again.'), 401
     elif not check_auth(username,password):
         print 'Change password:- Login Failed'
         return jsonify(error='Username and current password incorrect. Please try again.'), 401

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -193,7 +193,8 @@ def logout():
 # 
 @app.route('/change_password', methods=['POST'])
 def change_password():
-    username = request.form['name']
+    print 'CHANGING PASSWORD function'
+    username = request.form['change_pwd_name']
     password = request.form['current_password']
     new_password_1 = request.form['new_password_1']
     new_password_2 = request.form['new_password_2']


### PR DESCRIPTION
Change password modal now passes username to change_password().

I’ve tested and reviewed the code concerning login, change password and logout. The only problem I have found is that you can’t always navigate to “Change Password” and you can’t enter a url for it either (needed when we want to tell a user their new password and to go to www.url.com to change password). E.g. go to TTLL5 page, hit “Phenopolis”, go to user menu -> “Change Password” and you get nothing.