### PR TITLE
Add urls for change_password modal and login modal.

### DIFF
--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -66,6 +66,10 @@ if (!PP) {
         PP.submitChangePassword();
     });
 
+    $('#search_btn').on('click', function () {
+        window.location.href = '/search';
+    });
+
     // Open the login modal or the change password modal, if requested by the url.
     if (window.location.href.indexOf('#login') != -1) {
         $('#login_modal').modal('open');
@@ -111,6 +115,7 @@ if (!PP) {
     $('#change_password_btn').hide();
     $('#register_btn').hide();
     $('#submit_change_password_btn').hide();
+    $('#search_btn').hide();
 
     $('#login_btn').hide();
     $('#demo_login_btn').hide();
@@ -132,6 +137,7 @@ if (!PP) {
 
       $('#login_btn').hide();
       $('#demo_login_btn').hide();
+      $('#search_btn').hide();
 
       $('#register_content').hide();
       $('#submit_register_btn').hide();
@@ -155,6 +161,7 @@ if (!PP) {
     $('#enter_login_btn').hide();
     $('#submit_register_btn').hide();
     $('#submit_change_password_btn').hide();
+    $('#search_btn').hide();
   };
 
   //
@@ -204,6 +211,7 @@ if (!PP) {
               $('#auth_modal').modal('close');
               $('#change_password_successful').show();
               $("#change_password_successful").text(data.success);
+              $('#search_btn').show();
           },
           error: function (data, msg) {
               $('#auth_modal').modal('close');

--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -67,6 +67,13 @@ if (!PP) {
     });
 
     $(document).ready(function () {
+        if (window.location.href.indexOf('#login') != -1) {
+            $('#login_modal').modal('open');
+        }
+        if (window.location.href.indexOf('#change_password') != -1) {
+            $('#login_modal').modal('open');
+            PP.showChangePasswordForm();
+        }
         $("#new_password_1, #new_password_2").keyup(PP.checkPasswordMatch);
     });
 

--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -66,10 +66,6 @@ if (!PP) {
         PP.submitChangePassword();
     });
 
-    $('#search_btn').on('click', function () {
-        window.location.href = '/search';
-    });
-
     // Open the login modal or the change password modal, if requested by the url.
     if (window.location.href.indexOf('#login') != -1) {
         $('#login_modal').modal('open');

--- a/static/assets/js/home.js
+++ b/static/assets/js/home.js
@@ -66,16 +66,17 @@ if (!PP) {
         PP.submitChangePassword();
     });
 
-    $(document).ready(function () {
-        if (window.location.href.indexOf('#login') != -1) {
-            $('#login_modal').modal('open');
-        }
-        if (window.location.href.indexOf('#change_password') != -1) {
-            $('#login_modal').modal('open');
-            PP.showChangePasswordForm();
-        }
-        $("#new_password_1, #new_password_2").keyup(PP.checkPasswordMatch);
-    });
+    // Open the login modal or the change password modal, if requested by the url.
+    if (window.location.href.indexOf('#login') != -1) {
+        $('#login_modal').modal('open');
+    }
+    else if (window.location.href.indexOf('#change_password') != -1) {
+        $('#login_modal').modal('open');
+        PP.showChangePasswordForm();
+    }
+
+    // Change password modal - check the re-typing of the new password.
+    $("#new_password_1, #new_password_2").keyup(PP.checkPasswordMatch);
 
   };
 

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -102,7 +102,7 @@
         <a id="submit_change_password_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
         <a id="login_btn" href="#!" class="waves-effect waves-green btn-flat">Login</a>
         <a id="demo_login_btn" href="#!" class="waves-effect waves-green btn-flat">Demo Login</a>
-        <a id="search_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
+        <a id="search_btn" href="/search" class="waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
     </div>
 </div>
 <!-- Auth Modal -->

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -99,9 +99,10 @@
         <a id="enter_login_btn" href="#!" class="left waves-effect waves-green btn-flat" style="display:none;">Login</a>
         <!-- Right side of footer -->
         <a id="submit_register_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Submit</a>
-        <a id="submit_change_password_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
+        <a id="submit_change_password_btn" href="#!" class="right waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
         <a id="login_btn" href="#!" class="waves-effect waves-green btn-flat">Login</a>
         <a id="demo_login_btn" href="#!" class="waves-effect waves-green btn-flat">Demo Login</a>
+        <a id="search_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
     </div>
 </div>
 <!-- Auth Modal -->

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -100,7 +100,7 @@
         <!-- Right side of footer -->
         <a id="submit_register_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Submit</a>
         <a id="submit_change_password_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
-        <a id="search_btn" href="/search" class="center waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
+        <a id="search_btn" href="/search" class="waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
         <a id="login_btn" href="#!" class="waves-effect waves-green btn-flat">Login</a>
         <a id="demo_login_btn" href="#!" class="waves-effect waves-green btn-flat">Demo Login</a>
     </div>

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -100,9 +100,9 @@
         <!-- Right side of footer -->
         <a id="submit_register_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Submit</a>
         <a id="submit_change_password_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
+        <a id="search_btn" href="/search" class="center waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
         <a id="login_btn" href="#!" class="waves-effect waves-green btn-flat">Login</a>
         <a id="demo_login_btn" href="#!" class="waves-effect waves-green btn-flat">Demo Login</a>
-        <a id="search_btn" href="/search" class="waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>
     </div>
 </div>
 <!-- Auth Modal -->

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -99,7 +99,7 @@
         <a id="enter_login_btn" href="#!" class="left waves-effect waves-green btn-flat" style="display:none;">Login</a>
         <!-- Right side of footer -->
         <a id="submit_register_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Submit</a>
-        <a id="submit_change_password_btn" href="#!" class="right waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
+        <a id="submit_change_password_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Change Password</a>
         <a id="login_btn" href="#!" class="waves-effect waves-green btn-flat">Login</a>
         <a id="demo_login_btn" href="#!" class="waves-effect waves-green btn-flat">Demo Login</a>
         <a id="search_btn" href="#!" class="waves-effect waves-green btn-flat" style="display: none;">Search Phenopolis</a>

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -180,6 +180,11 @@ def login():
         return jsonify(success="Authenticated"), 200
 
 # 
+@app.route('/login', methods=['GET'])
+def login_form():
+    return redirect('/#login')
+
+# 
 @app.route('/logout')
 def logout():
     print('DELETE SESSION')
@@ -209,6 +214,12 @@ def change_password():
         db_users.users.update_one({'user':username},{'$set':{'argon_password':hash}})
         msg = 'Password for username \''+username+'\' changed. You are logged in as \''+username+'\'.' 
         return jsonify(success=msg), 200
+
+#
+@app.route('/change_password', methods=['GET'])
+def change_password_form():
+    return redirect('/#change_password')
+
 
 @app.route('/set/<query>')
 def set(query):

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -182,7 +182,10 @@ def login():
 # 
 @app.route('/login', methods=['GET'])
 def login_form():
-    return redirect('/#login')
+    if config.LOCAL:
+        return redirect('/#login')
+    else:
+        return redirect('https://uclex.cs.ucl.ac.uk/#login')
 
 # 
 @app.route('/logout')
@@ -218,7 +221,10 @@ def change_password():
 #
 @app.route('/change_password', methods=['GET'])
 def change_password_form():
-    return redirect('/#change_password')
+    if config.LOCAL:
+        return redirect('/#change_password')
+    else:
+        return redirect('https://uclex.cs.ucl.ac.uk/#change_password')
 
 
 @app.route('/set/<query>')


### PR DESCRIPTION
Add the ability to get to the Change Password screen directly from
https://......../#change_password
useful for when the admin has given a user a new password and wants to direct the user to immediately change their password.

Also added url to go directly to login screen
https://......./#login

Needs improvement - 
This works fine if your browser tab is not already on Phenopolis. However, if your tab is already open at Phenopolis home screen, then you need to enter the url https://......../#change_password **and** hit refresh in order to get the modal to pop up. 