### PR TITLE
Add simple neo4j test to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+dist: trusty  
 cache: pip
 # submodules is set to false to overcome a problem on Travis, we use the git line below instead.  
 git:
@@ -40,7 +41,7 @@ install:
 services:
   - mongodb
   - neo4j
-  - sleep 10
+
 script:
 # command to run coveralls (test coverage) and run tests 
   - coverage run --omit=*/site-packages/*,*/tests/* -m unittest discover -s tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
 
 services:
   - mongodb
-  
+  - neo4j
+  - sleep 10
 script:
 # command to run coveralls (test coverage) and run tests 
   - coverage run --omit=*/site-packages/*,*/tests/* -m unittest discover -s tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-Session==0.3.0
 hgvs==1.0.0a1
 mygene==3.0.0
 myvariant==0.3.1
-neo4j-driver==1.0.2
+neo4j-driver==1.4.0
 pandas==0.19.1
 phizz==0.2.3
 plotly==1.12.12

--- a/tests/test_neo4j.py
+++ b/tests/test_neo4j.py
@@ -1,0 +1,57 @@
+# Uncomment to run this module directly. TODO LMTW comment out.
+# import sys, os
+# sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+# End of uncomment.
+
+import unittest
+
+from neo4j.v1 import GraphDatabase, basic_auth
+
+class Neo4jTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.setup_driver()
+
+    def tearDown(self):
+        pass
+
+    def setup_driver(self):
+        local = False
+        password = "test" if local else "neo4j"
+        self.driver = GraphDatabase.driver("bolt://localhost:7687", auth=basic_auth("neo4j", password))
+        session = self.driver.session()
+
+        # Password handling taken from https://github.com/robinedwards/django-neomodel
+        try:
+            result = session.run("MATCH (a:Person) WHERE a.name = {name} "
+                                "RETURN a.name AS name, a.title AS title",
+                                {"name": "Crick"})
+        except CypherError as ce:
+            if 'The credentials you provided were valid, but must be changed before you can use this instance' in str(ce):
+                new_password = 'test'
+                session.run("CALL dbms.changePassword({password})", {'password': new_password})
+                print("New database with no password set, setting password to 'test'")
+            else:
+                raise ce
+
+    def test_neo4j(self):
+
+        session = self.driver.session()
+        session.run("CREATE (a:Person {name: {name}, title: {title}})",
+                    {"name": "Crick", "title": "Professor"})
+        result = session.run("MATCH (a:Person) WHERE a.name = {name} "
+                            "RETURN a.name AS name, a.title AS title",
+                            {"name": "Crick"})
+        for record in result:
+            print("%s %s" % (record["title"], record["name"]))
+        assert record["title"] == "Professor"
+        assert record["name"] == "Crick"
+
+        # clean up
+        session.run("MATCH (a:Person) WHERE a.name = {name} "
+                    "DETACH DELETE a",
+                    {"name": "Crick"})
+        session.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_neo4j.py
+++ b/tests/test_neo4j.py
@@ -1,4 +1,4 @@
-# Uncomment to run this module directly. TODO LMTW comment out.
+# Uncomment to run this module directly. TODO comment out.
 # import sys, os
 # sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 # End of uncomment.
@@ -24,7 +24,7 @@ class Neo4jTestCase(unittest.TestCase):
         # Password handling taken from https://github.com/robinedwards/django-neomodel
         try:
             result = session.run("MATCH (a:Person) WHERE a.name = {name} "
-                                "RETURN a.name AS name, a.title AS title",
+                                "RETURN a",
                                 {"name": "Crick"})
         except CypherError as ce:
             if 'The credentials you provided were valid, but must be changed before you can use this instance' in str(ce):


### PR DESCRIPTION
A simple test to show how tests that require neo4j can be run as part of the Travis build.

Changed dist to 'trusty' to get neo4j working with Travis. This will soon be the default that Travis uses anyway.